### PR TITLE
 Mechanical refining tech icon

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,9 @@
 ---------------------------------------------------------------------------------------------------
+Version: 2.1.4
+Date: ????
+  Changes:
+    - Changed tech icon for Mechanical refining to Ore sorting facility 1 when playing Sea Block
+---------------------------------------------------------------------------------------------------
 Version: 2.1.3
 Date: ????
   Bugfixes:

--- a/info.json
+++ b/info.json
@@ -1,6 +1,6 @@
 {
     "name": "reskins-angels",
-    "version": "2.1.3",
+    "version": "2.1.4",
     "factorio_version": "1.1",
     "title": "Artisanal Reskins: Angel's Mods",
     "author": "Kirazy",

--- a/prototypes/technology/refining.lua
+++ b/prototypes/technology/refining.lua
@@ -43,6 +43,11 @@ local technologies = {
     ["clowns-ore-floatation"] = {tier = 0, icon_name = "ore-flotation", technology_icon_layers = 1},
 }
 
+-- Sea Block compatibility
+if mods["SeaBlock"] then
+  technologies["ore-crushing"].icon_name = "advanced-ore-refining"
+end
+
 -- Check if we're using Angel's material colors
 if mods["bobwarfare"] and mods["bobplates"] and reskins.lib.setting("reskins-angels-use-angels-material-colors") then
     technologies["bob-armor-making-3"] = {group = "smelting", subgroup = "armor", flat_icon = true, technology_icon_mipmaps = 4}


### PR DESCRIPTION
Sea Block reshuffles the early tech tree:
- Ore crusher 1 is unlocked with Automation
- Tech icon for Mechanical refining is set to Ore sorting facility

![image](https://user-images.githubusercontent.com/59639/182008925-137ae604-d6b7-4819-bd90-bb90368ff910.png)

Reskins should set icon for Mechanical refining to Ore sorting facility 1
