### PR TITLE
Add flipped graphics set for hydro plant entity

### DIFF
--- a/prototypes/entity/refining/hydro-plant.lua
+++ b/prototypes/entity/refining/hydro-plant.lua
@@ -72,6 +72,39 @@ for name, map in pairs(tier_map) do
 				scale = 0.5,
 			},
 		},
+	}	
+	entity.graphics_set_flipped.animation = {
+		layers = {
+			-- Base
+			{
+				filename = "__angelsrefininggraphics__/graphics/entity/hydro-plant/hydro-plant-base.png",
+				priority = "extra-high",
+				width = 459,
+				height = 491,
+				shift = util.by_pixel(0, 0),
+				scale = 0.5,
+			},
+			-- Mask
+			{
+				filename = "__reskins-angels__/graphics/entity/refining/hydro-plant/hydro-plant-mask.png",
+				priority = "extra-high",
+				width = 459,
+				height = 491,
+				shift = util.by_pixel(0, 0),
+				tint = inputs.tint,
+				scale = 0.5,
+			},
+			-- Highlights
+			{
+				filename = "__reskins-angels__/graphics/entity/refining/hydro-plant/hydro-plant-highlights.png",
+				priority = "extra-high",
+				width = 459,
+				height = 491,
+				shift = util.by_pixel(0, 0),
+				blend_mode = reskins.lib.settings.blend_mode,
+				scale = 0.5,
+			},
+		},
 	}
 
 	::continue::


### PR DESCRIPTION
Adding declaration for "graphics_set_flipped", as the target entity has this, and when the building is flipped, it does not have anything from Reskins.

Appears to work: 


<img width="1591" height="1830" alt="hydro-plant-flipped" src="https://github.com/user-attachments/assets/86e62bad-0589-485b-8b55-df19bc6decf3" />
